### PR TITLE
Improve errors sent back to clients

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -271,7 +271,9 @@ func (conn *connection) readLoop() {
 				if conn.config.Authenticate != nil {
 					user, err := conn.config.Authenticate(data.AuthToken)
 					if err != nil {
-						conn.SendError(fmt.Errorf("Failed to authenticate user: %v", err))
+						msg := operationMessageForType(gqlConnectionError)
+						msg.Payload = fmt.Sprintf("Failed to authenticate user: %v", err)
+						conn.outgoing <- msg
 					} else {
 						conn.user = user
 						conn.outgoing <- operationMessageForType(gqlConnectionAck)


### PR DESCRIPTION
This corrects a mistake in how connections are rejected and also makes sure all error messages are returned the client (instead of empty objects).