### PR TITLE
Fix crash when clients close connections and improve the API a little bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ for _, conn := range subscriptions {
 			// Errors is optional ([]error)
 			Errors: graphqlws.ErrorsFromGraphQLErrors(result.Errors),
 		}
-		subscription.SendData(subscription, &data)
+		subscription.SendData(&data)
 	}
 }
 ```

--- a/handler.go
+++ b/handler.go
@@ -79,7 +79,7 @@ func NewHandler(config HandlerConfig) http.Handler {
 							Variables:     data.Variables,
 							OperationName: data.OperationName,
 							Connection:    conn,
-							SendData: func(subscription *Subscription, data *DataMessagePayload) {
+							SendData: func(data *DataMessagePayload) {
 								conn.SendData(opID, data)
 							},
 						})

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -21,7 +21,7 @@ func ErrorsFromGraphQLErrors(errors []gqlerrors.FormattedError) []error {
 
 // SubscriptionSendDataFunc is a function that sends updated data
 // for a specific subscription to the corresponding subscriber.
-type SubscriptionSendDataFunc func(*Subscription, *DataMessagePayload)
+type SubscriptionSendDataFunc func(*DataMessagePayload)
 
 // Subscription holds all information about a GraphQL subscription
 // made by a client, including a function to send data back to the

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -125,7 +125,7 @@ func TestSubscriptions_AddingValidSubscriptionsWorks(t *testing.T) {
 		ID:         "1",
 		Connection: &conn,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -149,7 +149,7 @@ func TestSubscriptions_AddingValidSubscriptionsWorks(t *testing.T) {
 		ID:         "2",
 		Connection: &conn,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -189,7 +189,7 @@ func TestSubscriptions_AddingSubscriptionsTwiceFails(t *testing.T) {
 		ID:         "1",
 		Connection: &conn,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -233,7 +233,7 @@ func TestSubscriptions_RemovingSubscriptionsWorks(t *testing.T) {
 		ID:         "1",
 		Connection: &conn,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -242,7 +242,7 @@ func TestSubscriptions_RemovingSubscriptionsWorks(t *testing.T) {
 		ID:         "2",
 		Connection: &conn,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -285,7 +285,7 @@ func TestSubscriptions_RemovingSubscriptionsOfAConnectionWorks(t *testing.T) {
 		ID:         "1",
 		Connection: &conn1,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -294,7 +294,7 @@ func TestSubscriptions_RemovingSubscriptionsOfAConnectionWorks(t *testing.T) {
 		ID:         "2",
 		Connection: &conn1,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -303,7 +303,7 @@ func TestSubscriptions_RemovingSubscriptionsOfAConnectionWorks(t *testing.T) {
 		ID:         "1",
 		Connection: &conn2,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}
@@ -312,7 +312,7 @@ func TestSubscriptions_RemovingSubscriptionsOfAConnectionWorks(t *testing.T) {
 		ID:         "2",
 		Connection: &conn2,
 		Query:      "subscription { users }",
-		SendData: func(s *graphqlws.Subscription, msg *graphqlws.DataMessagePayload) {
+		SendData: func(msg *graphqlws.DataMessagePayload) {
 			// Do nothing
 		},
 	}


### PR DESCRIPTION
This fixes #22 and removes the unnecessary and confusing subscription parameter from the `SendData` function.