### PR TITLE
subscriptions: Convert GraphQL errors to nil if they are empty

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -12,6 +12,10 @@ import (
 
 // ErrorsFromGraphQLErrors convert from GraphQL errors to regular errors.
 func ErrorsFromGraphQLErrors(errors []gqlerrors.FormattedError) []error {
+	if len(errors) == 0 {
+		return nil
+	}
+
 	out := make([]error, len(errors))
 	for i := range errors {
 		out[i] = errors[i]


### PR DESCRIPTION
This reduces the likelyhood of servers that use graphqlws to send
an empty array of errors along with subscription updates to clients.

This also makes subscriptions work better in GraphiQL, where
previously, the empty array of errors would make
GraphiQL-Subscriptions-Fetcher would treat all updates as errors:

https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher/blob/master/src/fetcher.ts#L36

(An empty array is considered truthy).